### PR TITLE
Add Nix flake support for reproducible builds

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Build artifacts
+termpix
+*.o
+*.exe
+
+# Nix
+result
+result-*
+.direnv/
+
+# Development
+compile_commands.json
+.cache/
+*.dSYM/
+
+# Editor
+.vscode/
+*.swp
+*~
+
+# Documentation
+CLAUDE.md
+
+# macOS
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Kelsi Davis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **TermPix** is a high-resolution terminal image renderer built in C. It transforms images into rich, colorful terminal graphics using half-block and braille rendering modes with automatic optimization based on image content.
 
+> **Note**: This is a fork of the original [TermPix by Kelsi Davis](https://github.com/Kelsidavis/TermPix) with added Nix flake support for reproducible builds and development environments.
+
 ---
 
 ## Features
@@ -124,6 +126,51 @@ Requires `stb_image.h` in the `lib/` directory.
 ```bash
 gcc -o termpix main.c render.c terminal.c image.c -lm
 ```
+
+---
+
+## 🐧 Nix Flake Support
+
+This fork includes full Nix flake support for reproducible builds and development environments.
+
+### Quick Start
+
+```bash
+# Run directly without installing
+nix run github:Kelsidavis/TermPix -- image.jpg
+
+# Install to your profile (permanent installation)
+nix profile install github:Kelsidavis/TermPix
+
+# Build the package
+nix build github:Kelsidavis/TermPix
+
+# Enter development shell with all tools
+nix develop github:Kelsidavis/TermPix
+```
+
+### Local Development
+
+```bash
+# Clone the repository
+git clone https://github.com/Kelsidavis/TermPix
+cd TermPix
+
+# Enter development environment
+nix develop
+
+# Build and run
+make
+./termpix screenshot.jpg
+```
+
+The development shell includes:
+- ✅ GCC compiler and build tools
+- ✅ GDB debugger
+- ✅ Static analysis (cppcheck)
+- ✅ Code formatting (clang-format)
+- ✅ Cross-compilation for Windows
+- ✅ Documentation tools (doxygen)
 
 ---
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1748693115,
+        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,133 @@
+{
+  description = "TermPix - High-resolution terminal image renderer";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        
+        termpix = pkgs.stdenv.mkDerivation rec {
+          pname = "termpix";
+          version = "2.0";
+          
+          src = ./.;
+          
+          buildInputs = with pkgs; [
+            # Math library is linked automatically by stdenv
+          ];
+          
+          nativeBuildInputs = with pkgs; [
+            gcc
+            gnumake
+          ];
+          
+          buildPhase = ''
+            make
+          '';
+          
+          installPhase = ''
+            mkdir -p $out/bin
+            cp termpix $out/bin/
+          '';
+          
+          meta = with pkgs.lib; {
+            description = "High-resolution terminal image renderer";
+            homepage = "https://github.com/jamesbrink/TermPix";
+            license = licenses.mit;
+            maintainers = [ ];
+            platforms = platforms.all;
+          };
+        };
+      in
+      {
+        packages = {
+          default = termpix;
+          termpix = termpix;
+        };
+        
+        apps = {
+          default = flake-utils.lib.mkApp {
+            drv = termpix;
+          };
+          termpix = flake-utils.lib.mkApp {
+            drv = termpix;
+          };
+        };
+        
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ termpix ];
+          
+          buildInputs = with pkgs; [
+            # Build tools
+            gcc
+            gnumake
+            cmake
+            pkg-config
+            
+            # Development tools
+            gdb
+            # valgrind # Not available on macOS
+            clang-tools
+            bear
+            
+            # Code formatting and linting
+            clang-tools
+            cppcheck
+            
+            # Documentation
+            doxygen
+            graphviz
+            
+            # Testing tools
+            python3
+            imagemagick
+            
+            # Version control
+            git
+            
+            # Editor support
+            ccls
+            
+            # Windows cross-compilation (optional)
+            pkgsCross.mingwW64.stdenv.cc
+          ];
+          
+          shellHook = ''
+            echo "TermPix Development Environment"
+            echo "==============================="
+            echo ""
+            echo "Available commands:"
+            echo "  make              - Build termpix"
+            echo "  make clean        - Clean build artifacts"
+            echo "  ./termpix <image> - Run termpix"
+            echo ""
+            echo "Development tools:"
+            echo "  gdb               - Debugger"
+            echo "  bear              - Compilation database generator"
+            echo "  cppcheck          - Static analyzer"
+            echo "  clang-format      - Code formatter"
+            echo ""
+            echo "Cross-compilation:"
+            echo "  x86_64-w64-mingw32-gcc - Windows cross-compiler"
+            echo ""
+            
+            # Set up development environment
+            export CFLAGS="-Wall -Wextra -pedantic -std=c99"
+            export CC="${pkgs.gcc}/bin/gcc"
+            
+            # Create compile_commands.json for better IDE support
+            if [ ! -f compile_commands.json ]; then
+              echo "Generating compile_commands.json..."
+              make clean > /dev/null 2>&1
+              bear -- make > /dev/null 2>&1
+              make clean > /dev/null 2>&1
+            fi
+          '';
+        };
+      });
+}


### PR DESCRIPTION
## Summary
- Adds comprehensive Nix flake support for reproducible builds and development
- Includes missing LICENSE file (MIT) crediting original author
- Updates README with Nix installation and usage instructions

## Motivation
This PR adds Nix flake support to make TermPix more accessible to Nix users and provides a reproducible build environment for development. Nix flakes ensure that all developers and users get the exact same dependencies and build environment, making it easier to contribute and debug issues.

## Changes
### New Files
- **flake.nix**: Defines the package build and development environment
- **flake.lock**: Pins exact dependency versions for reproducibility
- **.envrc**: Enables automatic environment loading with direnv
- **.gitignore**: Comprehensive ignore patterns for build artifacts
- **LICENSE**: MIT license file crediting Kelsi Davis as the original author

### Updated Files
- **README.md**: Added Nix flake usage section with installation instructions

## Features Added
The Nix flake provides:
- ✅ Reproducible builds across all platforms
- ✅ Three installation methods:
  - `nix run github:Kelsidavis/TermPix` - Run without installing
  - `nix profile install github:Kelsidavis/TermPix` - Permanent installation
  - `nix develop` - Enter development environment
- ✅ Complete development environment including:
  - GCC compiler and build tools
  - GDB debugger
  - Static analysis (cppcheck)
  - Code formatting (clang-format)
  - Documentation tools (doxygen)
  - Cross-compilation for Windows (MinGW)
- ✅ Automatic compile_commands.json generation for IDE support

## Testing
All Nix functionality has been tested:
- Build: `nix build` successfully compiles TermPix
- Run: `nix run . -- screenshot.jpg` executes correctly
- Development shell: `nix develop` provides all tools
- Cross-compilation: MinGW toolchain verified

## Compatibility
- Fully compatible with existing Makefile build system
- No changes to core TermPix functionality
- Nix support is optional - users can continue using traditional build methods

## Notes
- The .gitignore includes CLAUDE.md and .DS_Store for cleaner repository
- Development shell automatically sets appropriate CFLAGS
- Bear is included for generating compile_commands.json for better IDE integration

This addition makes TermPix more accessible to the Nix community while maintaining full backward compatibility with existing build methods.